### PR TITLE
Fix berkeley db version for osx

### DIFF
--- a/DigitalNote.pro
+++ b/DigitalNote.pro
@@ -530,16 +530,16 @@ isEmpty(BOOST_THREAD_LIB_SUFFIX) {
 }
 
 isEmpty(BDB_LIB_PATH) {
-    macx:BDB_LIB_PATH = /usr/local/Cellar/berkeley-db@4/4.8.30/lib
+    macx:BDB_LIB_PATH = /usr/local/Cellar/berkeley-db@6.2.32//lib
     windows:BDB_LIB_PATH=C:/dev/coindeps32/bdb-4.8/lib
 }
 
 isEmpty(BDB_LIB_SUFFIX) {
-    macx:BDB_LIB_SUFFIX = -4.8
+    macx:BDB_LIB_SUFFIX = -6.2
 }
 
 isEmpty(BDB_INCLUDE_PATH) {
-    macx:BDB_INCLUDE_PATH = /usr/local/Cellar/berkeley-db@4/4.8.30/include
+    macx:BDB_INCLUDE_PATH = /usr/local/Cellar/berkeley-db@6.2.32/include
     windows:BDB_INCLUDE_PATH=C:/dev/coindeps32/bdb-4.8/include
 }
 

--- a/DigitalNote.pro
+++ b/DigitalNote.pro
@@ -530,7 +530,7 @@ isEmpty(BOOST_THREAD_LIB_SUFFIX) {
 }
 
 isEmpty(BDB_LIB_PATH) {
-    macx:BDB_LIB_PATH = /usr/local/Cellar/berkeley-db@6.2.32//lib
+    macx:BDB_LIB_PATH = /usr/local/Cellar/berkeley-db@6.2.32/lib
     windows:BDB_LIB_PATH=C:/dev/coindeps32/bdb-4.8/lib
 }
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -31,30 +31,63 @@ You can get the current version from http://developer.apple.com
     ```git clone http://github.com/DigitalNotedev/DigitalNote DigitalNote``` 
 
 2. Install dependencies using Homebrew
-    1. Install dependencies:
-    ```
-   brew install boost@1.59
-   brew install berkeley-db4
-   brew install miniupnpc
-   brew install https://github.com/tebelorg/Tump/releases/download/v1.0.0/openssl.rb
-   brew install automake
-   brew install autoconf
-   brew install libtool
-   brew install qrencode
-   ```
-   2. You might need to create a symlink if `openssl/sha.h` or any other header from openssl/ folder cannot be found when building DigitalNoted:
-   ```
-   cd /usr/local/include
-   ln -s ../opt/openssl/include/openssl .
-   ```
-   Your compiler will search in this directory (one of many standard directories) and find the header file sha.h via the shortcut link.
-   
-   3. Now create a symlink to miniupnpc files since it is installed in a folder without a version appended and source files are expecting a version:
-   ```
-   cd /usr/local/include
-   ln -s ../opt/miniupnpc/include/miniupnpc ./miniupnpc-2.1
-   ``` 
-   4. Check the versions of dependencies in src/makefile.osx and amend to match yours if required 
+   1. Install dependencies:
+       ```
+       brew install boost@1.59
+       brew install miniupnpc
+       brew install https://github.com/tebelorg/Tump/releases/download/v1.0.0/openssl.rb
+       brew install automake
+       brew install autoconf
+       brew install libtool
+       brew install qrencode
+       ```
+   2. Install Berkeley-DB@6
+       Download:
+       
+       ```
+       curl -OL http://download.oracle.com/berkeley-db/db-6.2.32.tar.gz
+       ```
+       
+       Unzip:
+       ```
+       tar -xf db-6.2.32.tar.gz
+       ```
+       Build:
+       ```
+       cd db-6.2.32/build_unix                                              &&
+       ../dist/configure --prefix=/usr/local/Cellar/berkeley-db@6.2.32      \
+                         --enable-cxx                                       &&
+       make
+       ```
+      
+       If you get compile errors in `atomic.c` you need to apply a small patch and run the 'build' command above again: 
+       ```
+        cd ../..
+        curl -OL https://raw.githubusercontent.com/macports/macports-ports/cb92cb90bdc7fb90212e928db32172546eca0f5b/databases/db60/files/patch-src_dbinc_atomic.h
+        mv patch-src_dbinc_atomic.h db-6.2.32
+        cd db-6.2.32
+        patch -s -p0 < patch-src_dbinc_atomic.h
+        cd ..
+       ```
+      
+       Install:
+       ```
+        inside db-6.2.32/build_unix folder run:
+      
+        sudo make install
+       ```
+   3. You might need to create a symlink if `openssl/sha.h` or any other header from openssl/ folder cannot be found when building DigitalNoted:
+       ```
+       cd /usr/local/include
+       ln -s ../opt/openssl/include/openssl .
+       ```
+      Your compiler will search in this directory (one of many standard directories) and find the header file sha.h via the shortcut link.
+   4. Now create a symlink to miniupnpc files since it is installed in a folder without a version appended and source files are expecting a version:
+       ```
+       cd /usr/local/include
+       ln -s ../opt/miniupnpc/include/miniupnpc ./miniupnpc-2.1
+       ``` 
+   5. Check the versions of dependencies in src/makefile.osx and amend to match yours if required 
         
 3.  Now you should be able to build DigitalNoted:
 
@@ -91,7 +124,7 @@ DigitalNote-qt: Qt5 GUI Release for DigitalNote
    ```
    brew link qt5 --force
    ```
-3. Run in the ./DigitalNote
+3. Run in the ./DigitalNote-2
    ```
    qmake RELEASE=1 USE_UPNP=1 USE_QRCODE=1 DigitalNote.pro
    make

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -15,13 +15,13 @@ INCLUDEPATHS= \
  -I"$(CURDIR)"/obj \
  -I"$(DEPSDIR)/include" \
  -I"$(DEPSDIR)/Cellar/boost@1.59/1.59.0/include" \
- -I"$(DEPSDIR)/Cellar/berkeley-db@4/4.8.30/include" \
+ -I"$(DEPSDIR)/Cellar/berkeley-db@6.2.32/include" \
  -I"$(DEPSDIR)/Cellar/openssl/1.0.2t/lib"
 
 LIBPATHS= \
  -L"$(DEPSDIR)/lib" \
  -L"$(DEPSDIR)/Cellar/boost@1.59/1.59.0/lib" \
- -L"$(DEPSDIR)/Cellar/berkeley-db@4/4.8.30/lib" \
+ -L"$(DEPSDIR)/Cellar/berkeley-db@6.2.32/lib" \
  -L"$(DEPSDIR)/Cellar/openssl/1.0.2t/lib"
 
 USE_UPNP:=1
@@ -33,7 +33,7 @@ LIBS= -dead_strip
 ifdef STATIC
 # Build STATIC if you are redistributing the DigitalNoted binary
 LIBS += \
- $(DEPSDIR)/lib/db48/libdb_cxx-4.8.a \
+ $(DEPSDIR)/Cellar/berkeley-db@6.2.32/lib/libdb_cxx-6.2.a \
  $(DEPSDIR)/lib/libboost_system.a \
  $(DEPSDIR)/lib/libboost_filesystem.a \
  $(DEPSDIR)/lib/libboost_program_options.a \
@@ -43,7 +43,7 @@ LIBS += \
  -lz
 else
 LIBS += \
- -l db_cxx-4.8 \
+ -l db_cxx-6.2 \
  -l boost_system \
  -l boost_filesystem \
  -l boost_program_options \


### PR DESCRIPTION
bdb 4.8 is incorrect and is incompatible with the currently used bdb version(6.2). 
So they now match and it allows the wallet.dat's created in 1.0.2.5 to successfully initialise 