### PR TITLE
Typo fix

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -273,7 +273,7 @@ public:
     {
         switch (banReason) {
         case BanReasonNodeMisbehaving:
-            return "node misbehabing";
+            return "node misbehaving";
         case BanReasonManuallyAdded:
             return "manually added";
         default:


### PR DESCRIPTION
Typo fix on ban node reason